### PR TITLE
add collection create & delete operations

### DIFF
--- a/examples/annotate-document/pom.xml
+++ b/examples/annotate-document/pom.xml
@@ -25,7 +25,7 @@
       <groupId>com.idibon.api</groupId>
       <artifactId>java-sdk</artifactId>
       <relativePath>../../pom.xml</relativePath>
-      <version>1.0.1</version>
+      <version>1.0.2-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/examples/list-documents/pom.xml
+++ b/examples/list-documents/pom.xml
@@ -25,7 +25,7 @@
       <groupId>com.idibon.api</groupId>
       <artifactId>java-sdk</artifactId>
       <relativePath>../../pom.xml</relativePath>
-      <version>1.0.1</version>
+      <version>1.0.2-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/examples/predict-content/pom.xml
+++ b/examples/predict-content/pom.xml
@@ -25,7 +25,7 @@
       <groupId>com.idibon.api</groupId>
       <artifactId>java-sdk</artifactId>
       <relativePath>../../pom.xml</relativePath>
-      <version>1.0.1</version>
+      <version>1.0.2-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/examples/predict-idibon-public/pom.xml
+++ b/examples/predict-idibon-public/pom.xml
@@ -25,7 +25,7 @@
       <groupId>com.idibon.api</groupId>
       <artifactId>java-sdk</artifactId>
       <relativePath>../../pom.xml</relativePath>
-      <version>1.0.1</version>
+      <version>1.0.2-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/examples/upload-json-documents/pom.xml
+++ b/examples/upload-json-documents/pom.xml
@@ -25,7 +25,7 @@
       <groupId>com.idibon.api</groupId>
       <artifactId>java-sdk</artifactId>
       <relativePath>../../pom.xml</relativePath>
-      <version>1.0.1</version>
+      <version>1.0.2-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/java-api-client/pom.xml
+++ b/java-api-client/pom.xml
@@ -26,7 +26,7 @@
       <groupId>com.idibon.api</groupId>
       <artifactId>java-sdk</artifactId>
       <relativePath>../pom.xml</relativePath>
-      <version>1.0.1</version>
+      <version>1.0.2-SNAPSHOT</version>
   </parent>
 
   <profiles>

--- a/java-api-client/src/main/java/com/idibon/api/model/Annotation.java
+++ b/java-api-client/src/main/java/com/idibon/api/model/Annotation.java
@@ -231,6 +231,18 @@ public abstract class Annotation {
      */
     public abstract HttpFuture<JsonValue> deleteAsync();
 
+    @Override public boolean equals(Object other) {
+        if (other == this) return true;
+
+        if (!(other instanceof Annotation)) return false;
+
+        Annotation ann = (Annotation)other;
+        if (ann.uuid != null)
+            return ann.uuid.equals(this.uuid);
+
+        return false;
+    }
+
     /**
      * An Assignment annotation. Subclassed to DocumentAssignment and
      * SpanAssignment.

--- a/java-api-client/src/main/java/com/idibon/api/model/Collection.java
+++ b/java-api-client/src/main/java/com/idibon/api/model/Collection.java
@@ -269,6 +269,34 @@ public class Collection extends IdibonHash {
         return new TaskBuilder(this, scope).setName(name);
     }
 
+    /**
+     * Deletes this collection.
+     */
+    public void delete() throws IOException {
+        JsonObject body = JSON_BF.createObjectBuilder()
+            .add("collection", true).build();
+
+        Either<IOException, JsonObject> result =
+            _httpIntf.httpDelete(getEndpoint(), body).getAs(JsonObject.class);
+
+        if (result.isLeft()) throw result.left;
+        if (!result.right.getBoolean("deleted"))
+            throw new IOException ("Task was not deleted");
+
+        invalidate();
+        // propagate invalidation back to client's cache
+    }
+
+    /**
+     * Forces cached JSON data to be reloaded from the server.
+     */
+    @SuppressWarnings("unchecked")
+    @Override public Collection invalidate() {
+        super.invalidate();
+        for (Task t : _tasks.items()) t.invalidate();
+        return this;
+    }
+
     @Override public boolean equals(Object other) {
         if (other == this) return true;
         if (!(other instanceof Collection)) return false;

--- a/java-api-client/src/main/java/com/idibon/api/model/Collection.java
+++ b/java-api-client/src/main/java/com/idibon/api/model/Collection.java
@@ -281,7 +281,7 @@ public class Collection extends IdibonHash {
 
         if (result.isLeft()) throw result.left;
         if (!result.right.getBoolean("deleted"))
-            throw new IOException ("Task was not deleted");
+            throw new IOException("Collection was not deleted");
 
         invalidate();
         // propagate invalidation back to client's cache

--- a/java-api-client/src/test/java/com/idibon/api/IdibonAPITest.java
+++ b/java-api-client/src/test/java/com/idibon/api/IdibonAPITest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2015, Idibon, Inc.
+ */
+package com.idibon.api;
+
+import java.util.*;
+import javax.json.*;
+import java.lang.reflect.Method;
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.*;
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+
+public class IdibonAPITest {
+
+    @Test public void testValidateCollectionName() throws Throwable {
+        Method validateCollectionName = IdibonAPI.class
+            .getDeclaredMethod("validateCollectionName", String.class);
+        validateCollectionName.setAccessible(true);
+
+        assertInvalidCollectionName(validateCollectionName, "_test");
+        assertInvalidCollectionName(validateCollectionName, "Has Spaces");
+        assertInvalidCollectionName(validateCollectionName, "99Luftballoons");
+        assertInvalidCollectionName(validateCollectionName, "Luftballoons+99");
+        assertInvalidCollectionName(validateCollectionName, "A☃");
+
+        validateCollectionName.invoke(null, "this_is_acceptable");
+        validateCollectionName.invoke(null, "this-is-acceptable2");
+        validateCollectionName.invoke(null, "SoIsThis---");
+    }
+
+    private void assertInvalidCollectionName(Method validator, String name)
+            throws Throwable {
+        try {
+            try {
+                validator.invoke(null, name);
+                throw new RuntimeException("Should fail: " + name);
+            } catch (InvocationTargetException ex) {
+                throw ex.getCause();
+            }
+        } catch (IllegalArgumentException _) {
+            // ignore; this is expected for invalid names
+        }
+    }
+}

--- a/java-api-client/src/test/java/com/idibon/api/http/impl/JdkHttpInterfaceIT.java
+++ b/java-api-client/src/test/java/com/idibon/api/http/impl/JdkHttpInterfaceIT.java
@@ -69,7 +69,7 @@ public class JdkHttpInterfaceIT {
     @Test public void hostnameNotInCertificate() throws Throwable {
         // Parse out the 'https://' and any trailing slashes from the API link
         // since we want it to take the unsecured path
-        String apiTargetBase = _apiTarget.replaceAll("^https://([^/]+)/$", "$1");
+        String apiTargetBase = _apiTarget.replaceAll("^https://([^/]+)/?$", "$1");
 
         String addr = InetAddress.getByName(apiTargetBase).getHostAddress();
         JdkHttpInterface intf = new JdkHttpInterface()

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
    <groupId>com.idibon.api</groupId>
    <artifactId>java-sdk</artifactId>
-   <version>1.0.1</version>
+   <version>1.0.2-SNAPSHOT</version>
    <packaging>pom</packaging>
    <name>Idibon Java SDK</name>
    <description>Java SDK for Idibon text analytics web


### PR DESCRIPTION
add collection create and delete methods to the SDK

update most of the integration tests to use dynamically-created collections, which is a prerequisite for the tests to run for everyone with an API key.