### PR TITLE
add sample apps for navigating ontologies

### DIFF
--- a/examples/print-ontology/pom.xml
+++ b/examples/print-ontology/pom.xml
@@ -1,0 +1,70 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.idibon.api.java-sdk.examples</groupId>
+  <artifactId>print-ontology</artifactId>
+  <name>Idibon Java SDK Example: Print a Collection or Task Ontology</name>
+  <packaging>jar</packaging>
+   <description>Example application for Idibon Java SDK.</description>
+   <url>https://github.com/idibon/java-client</url>
+
+   <scm>
+       <url>git://github.com/idibon/java-client</url>
+   </scm>
+
+   <licenses>
+       <license>
+           <name>Apache License, Version 2.0</name>
+           <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+           <distribution>repo</distribution>
+       </license>
+   </licenses>
+
+  <parent>
+      <groupId>com.idibon.api</groupId>
+      <artifactId>java-sdk</artifactId>
+      <relativePath>../../pom.xml</relativePath>
+      <version>1.0.2-SNAPSHOT</version>
+  </parent>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-assembly-plugin</artifactId>
+              <executions>
+                  <execution>
+                      <phase>package</phase>
+                      <goals>
+                          <goal>attached</goal>
+                      </goals>
+                  </execution>
+              </executions>
+              <configuration>
+                  <archive>
+                      <manifest>
+                          <addClasspath>true</addClasspath>
+                          <classpathPrefix>lib/</classpathPrefix>
+                      </manifest>
+                  </archive>
+                  <descriptorRefs>
+                      <descriptorRef>jar-with-dependencies</descriptorRef>
+                  </descriptorRefs>
+              </configuration>
+          </plugin>
+      </plugins>
+  </build>
+
+  <dependencies>
+      <dependency>
+          <groupId>com.idibon.api.java-sdk</groupId>
+          <artifactId>java-api-client</artifactId>
+          <version>${project.version}</version>
+      </dependency>
+  </dependencies>
+</project>

--- a/examples/print-ontology/src/main/java/com/idibon/PrintOntology.java
+++ b/examples/print-ontology/src/main/java/com/idibon/PrintOntology.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2015, Idibon, Inc.
+ */
+package com.idibon;
+
+import java.util.*;
+import java.io.IOException;
+
+import com.idibon.api.http.impl.JdkHttpInterface;
+import com.idibon.api.model.*;
+import com.idibon.api.model.Collection;
+import com.idibon.api.IdibonAPI;
+import com.idibon.api.util.Either;
+
+import static com.idibon.api.model.DocumentAnnotationQuery.forTasks;
+
+/**
+ * Simple Idibon SDK example app listing the documents in a collection,
+ * optionally only those documents that have annotations on specific tasks.
+ */
+public class PrintOntology
+{
+    public static void printTaskOntology(Task node, Deque<Task> ancestors) throws Exception {
+        String indent = "";
+        for (int i = 0; i < ancestors.size(); i++) indent += "    ";
+        System.out.printf("%s -> %s\n", indent, node.getName());
+
+        ancestors.addLast(node);
+        indent += "    ";
+        for (Label label : node.getLabels()) {
+            System.out.printf("%s%s\n", indent, label.getName());
+            for (Task subtask : label.getSubtasks()) {
+                if (ancestors.contains(subtask)) {
+                    System.out.printf("%s -> %s [CIRCULAR]\n", indent,
+                                      label.getName(), subtask.getName());
+                } else {
+                    printTaskOntology(subtask, ancestors);
+                }
+            }
+        }
+
+        ancestors.removeLast();
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        if (args.length < 2) {
+            System.out.printf("Usage: %s API_KEY COLLECTION [TASK]\n",
+                              PrintOntology.class.getSimpleName());
+            return;
+        }
+
+        IdibonAPI client = new IdibonAPI()
+            .using(new JdkHttpInterface()
+                   .forServer("https://api.idibon.com")
+                   .withApiKey(args[0]));
+
+        try {
+            Collection collection = client.collection(args[1]);
+
+            List<Task> roots = args.length == 3
+                ? Arrays.asList(collection.task(args[2]))
+                : collection.getRootTasks();
+
+            for (Task rootTask : roots)
+                printTaskOntology(rootTask, new LinkedList<Task>());
+
+        } finally {
+            client.shutdown(0);
+        }
+    }
+}

--- a/examples/show-updated-tasks/pom.xml
+++ b/examples/show-updated-tasks/pom.xml
@@ -1,0 +1,78 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.idibon.api.java-sdk.examples</groupId>
+  <artifactId>show-updated-tasks</artifactId>
+  <name>Idibon Java SDK Example: Filtering Tasks by modification time</name>
+  <packaging>jar</packaging>
+   <description>Example application for Idibon Java SDK.</description>
+   <url>https://github.com/idibon/java-client</url>
+
+   <scm>
+       <url>git://github.com/idibon/java-client</url>
+   </scm>
+
+   <licenses>
+       <license>
+           <name>Apache License, Version 2.0</name>
+           <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+           <distribution>repo</distribution>
+       </license>
+   </licenses>
+
+  <parent>
+      <groupId>com.idibon.api</groupId>
+      <artifactId>java-sdk</artifactId>
+      <relativePath>../../pom.xml</relativePath>
+      <version>1.0.2-SNAPSHOT</version>
+  </parent>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-assembly-plugin</artifactId>
+              <executions>
+                  <execution>
+                      <phase>package</phase>
+                      <goals>
+                          <goal>attached</goal>
+                      </goals>
+                  </execution>
+              </executions>
+              <configuration>
+                  <archive>
+                      <manifest>
+                          <addClasspath>true</addClasspath>
+                          <classpathPrefix>lib/</classpathPrefix>
+                      </manifest>
+                  </archive>
+                  <descriptorRefs>
+                      <descriptorRef>jar-with-dependencies</descriptorRef>
+                  </descriptorRefs>
+              </configuration>
+          </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                  <source>1.8</source>
+                  <target>1.8</target>
+              </configuration>
+          </plugin>
+      </plugins>
+  </build>
+
+  <dependencies>
+      <dependency>
+          <groupId>com.idibon.api.java-sdk</groupId>
+          <artifactId>java-api-client</artifactId>
+          <version>${project.version}</version>
+      </dependency>
+  </dependencies>
+</project>

--- a/examples/show-updated-tasks/src/main/java/com/idibon/ShowUpdatedTasks.java
+++ b/examples/show-updated-tasks/src/main/java/com/idibon/ShowUpdatedTasks.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2015, Idibon, Inc.
+ */
+package com.idibon;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Arrays;
+import java.util.TimeZone;
+import java.util.stream.Collectors;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+
+import com.idibon.api.http.impl.JdkHttpInterface;
+import com.idibon.api.model.*;
+import com.idibon.api.IdibonAPI;
+import com.idibon.api.util.Either;
+
+import static com.idibon.api.model.DocumentAnnotationQuery.forTasks;
+
+/**
+ * Simple Idibon SDK example app that shows all of the tasks in a collection,
+ * and their associated subtasks, updated since a time specified using an
+ * ISO-8601 string provided on the command-line
+ */
+public class ShowUpdatedTasks
+{
+    private static boolean isUpdatedSince(Task task, Date since) {
+        try {
+            return task.getDate(Task.Keys.updated_at).compareTo(since) > 0;
+        } catch (Exception ex) {
+            throw new RuntimeException("Failed to compare update times", ex);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        if (args.length < 3) {
+            System.out.printf("Usage: %s API_KEY COLLECTION UPDATE-SINCE\n",
+                              ShowUpdatedTasks.class.getSimpleName());
+            return;
+        }
+
+        SimpleDateFormat iso8601Parser =
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        iso8601Parser.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        final Date since = iso8601Parser.parse(args[2]);
+
+        IdibonAPI client = new IdibonAPI()
+            .using(new JdkHttpInterface()
+                   .forServer("https://api.idibon.com")
+                   .withApiKey(args[0]));
+
+        try {
+            /* grab every task in the collection that has been updated after
+             * the time on the command-line */
+            List<Task> updatedTasks = client.collection(args[1])
+                .getAllTasks().stream()
+                .filter(task -> isUpdatedSince(task, since))
+                .collect(Collectors.toList());
+
+            for (Task t : updatedTasks)
+                System.out.printf("%s: updated at %s\n", t.getName(),
+                    iso8601Parser.format(t.getDate(Task.Keys.updated_at)));
+        } finally {
+            client.shutdown(0);
+        }
+    }
+}

--- a/java-api-client/src/main/java/com/idibon/api/model/Collection.java
+++ b/java-api-client/src/main/java/com/idibon/api/model/Collection.java
@@ -13,6 +13,7 @@ import com.idibon.api.model.Collection;
 import javax.json.*;
 
 import static com.idibon.api.model.Util.JSON_BF;
+import static com.idibon.api.model.Util.parseDate;
 import static com.idibon.api.model.OntologyNode.CONFIG_SUBTASK_KEY;
 
 /**
@@ -101,6 +102,42 @@ public class Collection extends IdibonHash {
     @SuppressWarnings("unchecked")
     public <T extends JsonValue> T get(Keys key) throws IOException {
         return (T)getJson().get(key.name());
+    }
+
+    /**
+     * Returns the document UUID
+     */
+    public UUID getUUID() throws IOException {
+        UUID uuid = (UUID)getCache().get(Keys.uuid);
+
+        if (uuid == null) {
+            String raw = getJson().getString(Keys.uuid.name(), null);
+            uuid = UUID.fromString(raw);
+            getCache().put(Keys.uuid, uuid);
+        }
+
+        return uuid;
+    }
+
+    /**
+     * Returns one of the Date keys, or null.
+     *
+     * @param dateKey The date value to retrieve
+     * @return The requested date, or null.
+     */
+    public Date getDate(Keys dateKey) throws IOException {
+        if (dateKey != Keys.updated_at && dateKey != Keys.created_at &&
+              dateKey != Keys.touched_at) {
+            throw new IllegalArgumentException("Not a date key");
+        }
+
+        Date date = (Date)getCache().get(dateKey);
+        if (date == null) {
+            date = parseDate(getJson().getString(dateKey.name(), null));
+            if (date != null) getCache().put(dateKey, date);
+        }
+
+        return date;
     }
 
     /**

--- a/java-api-client/src/main/java/com/idibon/api/model/Document.java
+++ b/java-api-client/src/main/java/com/idibon/api/model/Document.java
@@ -5,7 +5,6 @@ package com.idibon.api.model;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
 import com.idibon.api.util.Either;
 import com.idibon.api.http.*;
@@ -266,7 +265,6 @@ public class Document extends IdibonHash
     @SuppressWarnings("unchecked")
     @Override public Document invalidate() {
         super.invalidate();
-        _jsonCache = null;
         return this;
     }
 
@@ -286,22 +284,6 @@ public class Document extends IdibonHash
         return instance(parent, name).preload(obj);
     }
 
-    /**
-     * Safely get the cache instance, instantiating one if it doesn't
-     * already exist.
-     */
-    private Map<Keys, Object> getCache() {
-        /* this is racy, but the only negative outcome is that multiple
-         * threads may each instantiate a ConcurrentHashMap, and all but
-         * one of the instances will be GCd immediately. */
-        Map<Keys, Object> map = _jsonCache;
-        if (map == null) {
-            map = new ConcurrentHashMap<>();
-            _jsonCache = map;
-        }
-        return map;
-    }
-
     private Document(String name, Collection parent, HttpInterface httpIntf) {
         super(parent.getEndpoint() + "/" + percentEncode(name), httpIntf);
         _name = name;
@@ -310,8 +292,4 @@ public class Document extends IdibonHash
 
     private final Collection _parent;
     private final String _name;
-
-    /* Simple cache of data loaded from the JsonObject, to avoid expensive
-     * repetitive parsing. */
-    private volatile Map<Keys, Object> _jsonCache;
 }

--- a/java-api-client/src/main/java/com/idibon/api/model/Task.java
+++ b/java-api-client/src/main/java/com/idibon/api/model/Task.java
@@ -13,6 +13,7 @@ import com.idibon.api.util.Memoize;
 import com.idibon.api.http.HttpInterface;
 import com.idibon.api.model.Collection;
 import static com.idibon.api.model.Util.JSON_BF;
+import static com.idibon.api.model.Util.*;
 import static com.idibon.api.model.TuningRules.CONFIG_TUNING_KEY;
 import static com.idibon.api.model.OntologyNode.CONFIG_SUBTASK_KEY;
 
@@ -205,6 +206,42 @@ public class Task extends IdibonHash {
     @SuppressWarnings("unchecked")
     public <T extends JsonValue> T get(Keys key) throws IOException {
         return (T)getJson().get(key.name());
+    }
+
+    /**
+     * Returns the task UUID
+     */
+    public UUID getUUID() throws IOException {
+        UUID uuid = (UUID)getCache().get(Keys.uuid);
+
+        if (uuid == null) {
+            String raw = getJson().getString(Keys.uuid.name(), null);
+            uuid = UUID.fromString(raw);
+            getCache().put(Keys.uuid, uuid);
+        }
+
+        return uuid;
+    }
+
+    /**
+     * Returns one of the Date keys, or null.
+     *
+     * @param dateKey The date value to retrieve
+     * @return The requested date, or null.
+     */
+    public Date getDate(Keys dateKey) throws IOException {
+        if (dateKey != Keys.updated_at && dateKey != Keys.created_at &&
+              dateKey != Keys.trained_at && dateKey != Keys.touched_at) {
+            throw new IllegalArgumentException("Not a date key");
+        }
+
+        Date date = (Date)getCache().get(dateKey);
+        if (date == null) {
+            date = parseDate(getJson().getString(dateKey.name(), null));
+            if (date != null) getCache().put(dateKey, date);
+        }
+
+        return date;
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,17 @@
        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
    </properties>
 
+  <profiles>
+      <profile>
+          <activation>
+              <jdk>1.8</jdk>
+          </activation>
+          <modules>
+              <module>examples/show-updated-tasks</module>
+          </modules>
+      </profile>
+  </profiles>
+
    <modules>
        <module>java-api-client</module>
        <module>examples/list-documents</module>

--- a/pom.xml
+++ b/pom.xml
@@ -48,5 +48,6 @@
        <module>examples/annotate-document</module>
        <module>examples/predict-content</module>
        <module>examples/predict-idibon-public</module>
+       <module>examples/print-ontology</module>
    </modules>
 </project>


### PR DESCRIPTION
Add a couple of sample apps that demonstrate manipulating tasks and ontologies in the SDK:

* show-updated-tasks shows all tasks modified in a collection since a time supplied on the command line. this example also demonstrates integrating the Idibon SDK with JDK8 stream / lambda operations

* print-ontology recursively prints an ontology, or a branch of an ontology

add a few helper methods to com.idibon.api.model.Collection and com.idibon.api.model.Task that already existed on com.idibon.api.model.Document to make it easier to access the updated-at time (among other properties).