### PR TITLE
ENG-473: add CI support for java SDK

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,18 @@
+machine:
+  java:
+    version: oraclejdk8
+
+general:
+  branches:
+    ignore:
+      - gh-pages
+  artifacts:
+    - "java-api-client/target/*.jar"
+    - "java-api-client/target/surefire-reports/*.txt"
+    - "java-api-client/target/failsafe-reports/*.txt"
+
+dependencies:
+  override:
+    # ensure that example app dependencies on the project parent
+    # don't result in false test failures
+    - mvn --fail-never dependency:go-offline || true

--- a/examples/show-updated-tasks/pom.xml
+++ b/examples/show-updated-tasks/pom.xml
@@ -60,9 +60,11 @@
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-compiler-plugin</artifactId>
+              <version>3.2</version>
               <configuration>
                   <source>1.8</source>
                   <target>1.8</target>
+                  <encoding>UTF-8</encoding>
               </configuration>
           </plugin>
       </plugins>

--- a/examples/upload-json-documents/pom.xml
+++ b/examples/upload-json-documents/pom.xml
@@ -71,20 +71,6 @@
                   </descriptorRefs>
               </configuration>
           </plugin>
-          <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>3.2</version>
-              <configuration>
-                  <compilerArgs>
-                      <arg>-Xlint:unchecked</arg>
-                      <arg>-Xlint:deprecation</arg>
-                  </compilerArgs>
-                  <source>1.7</source>
-                  <target>1.7</target>
-                  <encoding>UTF-8</encoding>
-              </configuration>
-          </plugin>
       </plugins>
   </build>
 

--- a/java-api-client/pom.xml
+++ b/java-api-client/pom.xml
@@ -82,6 +82,14 @@
                   <nohelp>true</nohelp>
               </configuration>
           </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.4.1</version>
+              <configuration>
+                  <argLine>-Xmx64m</argLine>
+              </configuration>
+          </plugin>
       </plugins>
   </build>
 


### PR DESCRIPTION
fix a couple of POM bugs in the examples that were flagged as
warnings when building in CI, and explicily limit the heap size
for integration tests so that the run-to-OOME MemoizeTest doesn't
cause the CircleCI host to start SIGBUS'ing