### PR TITLE
ENG-1852: read confidence thresholds

### DIFF
--- a/java-api-client/src/main/java/com/idibon/api/model/DocumentSearcher.java
+++ b/java-api-client/src/main/java/com/idibon/api/model/DocumentSearcher.java
@@ -448,11 +448,15 @@ public class DocumentSearcher
                 }
             }
 
-            _nextStart += _currentBatch.right.size();
-            _limitRemain -= _currentBatch.right.size();
+            if (_currentBatch.isRight()) {
+                _nextStart += _currentBatch.right.size();
+                _limitRemain -= _currentBatch.right.size();
 
-            // pre-load the next batch if one exists
-            if (cursor != null && _limitRemain > 0) dispatchNext(cursor);
+                // pre-load the next batch if one exists
+                if (cursor != null && _limitRemain > 0) dispatchNext(cursor);
+            } else {
+                if (_limitRemain > 0) dispatchNext(null);
+            }
         }
 
         /**

--- a/java-api-client/src/main/java/com/idibon/api/model/Label.java
+++ b/java-api-client/src/main/java/com/idibon/api/model/Label.java
@@ -17,6 +17,12 @@ import static com.idibon.api.model.Util.JSON_BF;
  */
 public class Label {
 
+    /**
+     * The default confidence threshold value returned by
+     * {@link com.idibon.api.model.Label#getConfidenceThreshold} if a custom
+     * threshold for this label is not defined. 0.5 indicates 50% confidence.
+     */
+    public static final double DEFAULT_CONFIDENCE_THRESHOLD = 0.5;
     static final String CONFIG_CONFIDENCE_THRESHOLDS_KEY = "confidence_thresholds";
 
     /**
@@ -94,6 +100,31 @@ public class Label {
      */
     public String getName() {
         return _name;
+    }
+
+    /**
+     * Returns the suggested confidence threshold (i.e., accept / reject
+     * threshold) for classifications using this label, if present, or
+     * returns DEFAULT_CONFIDENCE_THRESHOLD.
+     */
+    public double getConfidenceThreshold() throws IOException {
+        JsonObject config = _task.get(Task.Keys.config);
+        if (config == null) return DEFAULT_CONFIDENCE_THRESHOLD;
+
+        JsonObject thresholds =
+            config.getJsonObject(CONFIG_CONFIDENCE_THRESHOLDS_KEY);
+        if (thresholds == null) return DEFAULT_CONFIDENCE_THRESHOLD;
+
+        JsonObject labels = thresholds.getJsonObject("labels");
+        if (labels == null) return DEFAULT_CONFIDENCE_THRESHOLD;
+
+        JsonObject thisLabel = labels.getJsonObject(getName());
+        if (thisLabel == null) return DEFAULT_CONFIDENCE_THRESHOLD;
+
+        JsonNumber suggested = thisLabel.getJsonNumber("suggested");
+        return (suggested != null) ?
+            suggested.doubleValue() :
+            DEFAULT_CONFIDENCE_THRESHOLD;
     }
 
     /**

--- a/java-api-client/src/main/java/com/idibon/api/model/Label.java
+++ b/java-api-client/src/main/java/com/idibon/api/model/Label.java
@@ -17,6 +17,8 @@ import static com.idibon.api.model.Util.JSON_BF;
  */
 public class Label {
 
+    static final String CONFIG_CONFIDENCE_THRESHOLDS_KEY = "confidence_thresholds";
+
     /**
      * Keys that may be present in a Label JSON.
      */

--- a/java-api-client/src/test/java/com/idibon/api/model/LabelTest.java
+++ b/java-api-client/src/test/java/com/idibon/api/model/LabelTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2015, Idibon, Inc.
+ */
+package com.idibon.api.model;
+
+import org.junit.*;
+import javax.json.*;
+
+import java.io.StringReader;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+
+public class LabelTest {
+
+    private void testConfidenceThreshold(String json,
+            String labelName, double expected) throws Exception {
+
+        JsonObject taskJson = Json.createReader(new StringReader(json)).readObject();
+        Collection mockCollection = Collection.instance(null, "C");
+        Task mockTask = Task.instance(mockCollection, taskJson);
+        Label mockLabel = mockTask.label(labelName);
+        assertThat(mockLabel.getConfidenceThreshold(), is(equalTo(expected)));
+    }
+
+    @Test public void testCustomConfidenceThreshold() throws Exception {
+        String json =
+          "{\"task\":{" +
+              "\"scope\":\"document\"," +
+              "\"config\":{" +
+               "\"confidence_thresholds\":{\"labels\":{" +
+                 "\"Label\":{\"suggested\":0.75}" +
+               "}}" +
+              "},"+
+              "\"labels\":[" +
+                "{\"name\":\"Label\",\"description\":\"\"," +
+                 "\"uuid\":\"00000000-0000-0000-0000-000000000001\"}]," +
+              "\"uuid\":\"00000000-0000-0000-0000-000000000000\"," +
+              "\"name\":\"task\"}}";
+        testConfidenceThreshold(json, "Label", 0.75);
+    }
+
+    @Test public void testDefaultConfidenceThreshold() throws Exception {
+        String json =
+          "{\"task\":{" +
+              "\"scope\":\"document\"," +
+              "\"labels\":[" +
+                "{\"name\":\"Label\",\"description\":\"\"," +
+                 "\"uuid\":\"00000000-0000-0000-0000-000000000001\"}]," +
+              "\"uuid\":\"00000000-0000-0000-0000-000000000000\"," +
+              "\"name\":\"task\"}}";
+        testConfidenceThreshold(json, "Label", Label.DEFAULT_CONFIDENCE_THRESHOLD);
+    }
+
+    @Test public void testDescription() throws Exception {
+        String json =
+          "{\"task\":{" +
+              "\"scope\":\"document\"," +
+              "\"labels\":[" +
+                "{\"name\":\"Boo!\",\"description\":\"A Ghost!\"," +
+                 "\"uuid\":\"00000000-0000-0000-0000-000000000001\"}]," +
+              "\"uuid\":\"00000000-0000-0000-0000-000000000000\"," +
+              "\"name\":\"task\"}}";
+
+        JsonObject taskJson = Json.createReader(new StringReader(json)).readObject();
+        Collection mockCollection = Collection.instance(null, "C");
+        Task mockTask = Task.instance(mockCollection, taskJson);
+        Label mockLabel = mockTask.label("Boo!");
+        assertThat(mockLabel.getDescription(), is(equalTo("A Ghost!")));
+    }
+
+    @Test(expected = java.util.NoSuchElementException.class)
+    public void testInvalidLabel() throws Exception {
+        String json =
+          "{\"task\":{" +
+              "\"scope\":\"document\"," +
+              "\"labels\":[" +
+                "{\"name\":\"Label\",\"description\":\"\"," +
+                 "\"uuid\":\"00000000-0000-0000-0000-000000000001\"}]," +
+              "\"uuid\":\"00000000-0000-0000-0000-000000000000\"," +
+              "\"name\":\"task\"}}";
+
+        JsonObject taskJson = Json.createReader(new StringReader(json)).readObject();
+        Collection mockCollection = Collection.instance(null, "C");
+        Task mockTask = Task.instance(mockCollection, taskJson);
+        Label mockLabel = mockTask.label("Boo!");
+        mockLabel.getDescription();
+    }
+}

--- a/java-api-client/src/test/java/com/idibon/api/model/TaskTest.java
+++ b/java-api-client/src/test/java/com/idibon/api/model/TaskTest.java
@@ -59,55 +59,55 @@ public class TaskTest {
             (Set)new HashSet(Arrays.asList(mockCollection.task("sub1"),
                                            mockCollection.task("sub2")))));
     }
-    
+
     @Test public void testTrivialRules() throws Exception {
         String json = "{\"task\":{\"uuid\":\"00000000-0000-0000-0000-000000000000\"," +
-            "\"name\":\"ClassifyCats\",\"scope\":\"document\"," + 
+            "\"name\":\"ClassifyCats\",\"scope\":\"document\"," +
             "\"labels\":[{\"name\":\"American Short Hair\"},{\"name\":\"Siamese\"}," +
             "{\"name\":\"Persian\"},{\"name\":\"Burmese\"},{\"name\":\"Siberian\"}," +
             "{\"name\":\"Balinese\"},{\"name\":\"Russian Blue\"},{\"name\":\"Maine Coon\"}]," +
             "\"features\":[{\"uuid\":\"00000000-0000-0000-0000-000000000001\"," +
             "\"name\":\"ClarabridgeRule\",\"parameters\":{\"label_rules\":" +
             "\"{\\\"American Short Hair\\\":[[\\\"\\\",\\\"\\\",\\\"\\\",\\\"\\\"]],\\\"Siamese\\\":[[\\\"\\\",\\\"\\\",\\\"\\\",\\\"\\\"]]," +
-            "\\\"Persian\\\":[[\\\"\\\",\\\"\\\",\\\"\\\",\\\"\\\"]]," + 
+            "\\\"Persian\\\":[[\\\"\\\",\\\"\\\",\\\"\\\",\\\"\\\"]]," +
             "\\\"Burmese\\\":[[\\\"\\\",\\\"\\\",\\\"\\\",\\\"\\\"]],\\\"Siberian\\\":[[\\\"\\\",\\\"\\\",\\\"\\\",\\\"\\\"]]," +
             "\\\"Balinese\\\":[[\\\"\\\",\\\"\\\",\\\"\\\",\\\"\\\"]],\\\"Russian Blue\\\":[[\\\"\\\",\\\"\\\",\\\"\\\",\\\"\\\"]]," +
             "\\\"Maine Coon\\\":[[\\\"\\\",\\\"\\\",\\\"\\\",\\\"\\\"]]}\"},\"is_active\":true}]}}";
-        
+
         JsonObject taskJson = Json.createReader(new StringReader(json)).readObject();
         Collection mockCollection = Collection.instance(null, "C");
         Task mockTask = Task.instance(mockCollection, taskJson);
 
-        /* Creating fake documents. This could really be anything, since it won't be used in 
+        /* Creating fake documents. This could really be anything, since it won't be used in
          * an actual prediction. Since there are no rules, it is a trivial accept */
         Document mockDocument = Document.instance(mockCollection, "Cats are similar in anatomy to the " +
-            "other felids, with strong, flexible bodies, quick reflexes, sharp retractable claws, " + 
+            "other felids, with strong, flexible bodies, quick reflexes, sharp retractable claws, " +
             "and teeth adapted to killing small prey.");
         List<DocumentContent> docs = new ArrayList();
         for (int i = 0; i < 2; i++) {
             docs.add(mockDocument);
         }
-        
+
         // Ensure that the top-level prediction is 1.0
         PredictionIterable<DocumentPrediction> prediction = mockTask.classifications(docs);
         JsonArray predictionJson = prediction.iterator().next().right.getJson();
         assert(predictionJson.getJsonObject(0).get("confidence").toString().equals("1.0"));
-        
+
         // Ensure that all labels are predicted as 1.0
         JsonObject labels = predictionJson.getJsonObject(0).getJsonObject("classes");
         for (String label : labels.keySet()) {
             assert(labels.get(label).toString().equals("1.0"));
         }
-        
+
         // Ensure that there are no features
         assert(predictionJson.getJsonObject(0).get("features") == null);
-        
+
         // Specify that we want to see features, then ensure that an empty feature object is included
         prediction = prediction.withSignificantFeatures();
         predictionJson = prediction.iterator().next().right.getJson();
         assert(predictionJson.getJsonObject(0).get("features").toString().equals("{}"));
     }
-    
+
     @Test public void testNontrivialRules() throws Exception {
         String json = "{\"task\":{\"uuid\":\"00000000-0000-0000-0000-000000000000\",\"name\":\"ClassifyCats\"," +
             "\"collection_id\":\"00000000-0000-0000-0000-000000000001\",\"description\":\"ClassifyCats\"," +
@@ -126,34 +126,64 @@ public class TaskTest {
         JsonObject taskJson = Json.createReader(new StringReader(json)).readObject();
         Collection mockCollection = Collection.instance(null, "C");
         Task mockTask = Task.instance(mockCollection, taskJson);
-        
+
         java.lang.reflect.Method method = Task.class.getDeclaredMethod("isTrivialAccept");
         method.setAccessible(true);
 
         assertThat(((boolean)method.invoke(mockTask)), is(false));
     }
-    
+
     @Test public void testNontrivialRules2() throws Exception {
         String json = "{\"task\":{\"uuid\":\"00000000-0000-0000-0000-000000000000\"," +
-                "\"name\":\"ClassifyCats\",\"scope\":\"document\"," + 
+                "\"name\":\"ClassifyCats\",\"scope\":\"document\"," +
                 "\"labels\":[{\"name\":\"American Short Hair\"},{\"name\":\"Siamese\"}," +
                 "{\"name\":\"Persian\"},{\"name\":\"Burmese\"},{\"name\":\"Siberian\"}," +
                 "{\"name\":\"Balinese\"},{\"name\":\"Russian Blue\"},{\"name\":\"Maine Coon\"}]," +
                 "\"features\":[{\"uuid\":\"00000000-0000-0000-0000-000000000001\"," +
                 "\"name\":\"ClarabridgeRule\",\"parameters\":{\"label_rules\":" +
                 "\"{\\\"American Short Hair\\\":[[\\\"\\\",\\\"\\\",\\\"\\\",\\\"\\\"]],\\\"Siamese\\\":[[\\\"\\\",\\\"\\\",\\\"\\\",\\\"\\\"]]," +
-                "\\\"Persian\\\":[[\\\"\\\",\\\"\\\",\\\"white\\\",\\\"\\\"]]," + 
+                "\\\"Persian\\\":[[\\\"\\\",\\\"\\\",\\\"white\\\",\\\"\\\"]]," +
                 "\\\"Burmese\\\":[[\\\"\\\",\\\"\\\",\\\"\\\",\\\"\\\"]],\\\"Siberian\\\":[[\\\"\\\",\\\"\\\",\\\"\\\",\\\"\\\"]]," +
                 "\\\"Balinese\\\":[[\\\"\\\",\\\"\\\",\\\"\\\",\\\"\\\"]],\\\"Russian Blue\\\":[[\\\"\\\",\\\"\\\",\\\"\\\",\\\"\\\"]]," +
                 "\\\"Maine Coon\\\":[[\\\"\\\",\\\"\\\",\\\"\\\",\\\"\\\"]]}\"},\"is_active\":true}]}}";
-        
+
         JsonObject taskJson = Json.createReader(new StringReader(json)).readObject();
         Collection mockCollection = Collection.instance(null, "C");
         Task mockTask = Task.instance(mockCollection, taskJson);
-        
+
         java.lang.reflect.Method method = Task.class.getDeclaredMethod("isTrivialAccept");
         method.setAccessible(true);
 
         assertThat((boolean)method.invoke(mockTask), is(false));
+    }
+
+    @Test public void testUpdateConfigHash() throws Exception {
+        java.lang.reflect.Method method =
+            Task.class.getDeclaredMethod("getUpdatedConfigHash",
+                JsonObject.class, String.class, String.class);
+
+        method.setAccessible(true);
+
+        String json = "{\"tuning\":{\"A\":{}}," +
+            "\"sub_tasks\":{\"A\":[\"subtask\"]}," +
+            "\"confidence_thresholds\":{\"labels\":{" +
+            "\"A\":{\"suggested\":0.875}}}}";
+
+        JsonObject configJson = Json.createReader(new StringReader(json)).readObject();
+        JsonObject r = (JsonObject)method.invoke(null, configJson, "A", "B");
+        assertThat(r.getJsonObject("tuning"), hasKey("B"));
+        assertThat(r.getJsonObject("tuning").size(), is(1));
+        assertThat(r.getJsonObject("sub_tasks"), hasKey("B"));
+        assertThat(r.getJsonObject("sub_tasks").size(), is(1));
+        assertThat(r.getJsonObject("confidence_thresholds")
+                   .getJsonObject("labels"), hasKey("B"));
+        assertThat(r.getJsonObject("confidence_thresholds")
+                   .getJsonObject("labels").size(), is(1));
+
+        r = (JsonObject)method.invoke(null, configJson, "A", null);
+        assertThat(r.getJsonObject("tuning").keySet(), is(empty()));
+        assertThat(r.getJsonObject("sub_tasks").keySet(), is(empty()));
+        assertThat(r.getJsonObject("confidence_thresholds")
+                    .getJsonObject("labels").keySet(), is(empty()));
     }
 }


### PR DESCRIPTION
add a helper method to the Label class to enable applications to access any
confidence thresholds stored in the task config structure.

also update the Label rename / delete propagation to also propagate to the
confidence threshold structure. this method was becoming complex enough
that I did a bit of refactoring so that all of the JsonObject propagation code
can be directly unit tested.

cc: @texasmichelle 