### PR TITLE
Fixing wording around trivial predict case.

### DIFF
--- a/java-api-client/src/main/java/com/idibon/api/model/PredictionIterableNontrivial.java
+++ b/java-api-client/src/main/java/com/idibon/api/model/PredictionIterableNontrivial.java
@@ -60,6 +60,12 @@ class PredictionIterableNontrivial<T extends Prediction<T>>
         return this;
     }
 
+    /**
+     * Used for regular prediction cases.
+     * @param clazz
+     * @param target
+     * @param items
+     */
     PredictionIterableNontrivial(Class<T> clazz, Task target,
           Iterable<? extends DocumentContent> items) {
         try {

--- a/java-api-client/src/main/java/com/idibon/api/model/PredictionIterableTrivial.java
+++ b/java-api-client/src/main/java/com/idibon/api/model/PredictionIterableTrivial.java
@@ -56,6 +56,12 @@ class PredictionIterableTrivial<T extends Prediction<T>>
         return this;
     }
 
+    /**
+     * Used in the case of Trivial Clarabridge Rules.
+     * @param clazz
+     * @param target
+     * @param items
+     */
     PredictionIterableTrivial(Class<T> clazz, Task target,
           Iterable<? extends DocumentContent> items) {
         try {
@@ -77,7 +83,7 @@ class PredictionIterableTrivial<T extends Prediction<T>>
     
     /**
      * Private helper function to generate a stock prediction tree for use
-     * in trivial accept cases. Returns an array consisting of a single prediction
+     * in trivial clarabridge accept cases. Returns an array consisting of a single prediction
      * with confidence levels set to 1.0 for all labels.
      */
     private JsonArray getTrivialAcceptPrediction() throws IOException {

--- a/java-api-client/src/main/java/com/idibon/api/model/Task.java
+++ b/java-api-client/src/main/java/com/idibon/api/model/Task.java
@@ -148,9 +148,10 @@ public class Task extends IdibonHash {
         if (getScope() != Scope.document)
             throw new UnsupportedOperationException("Not a document task");
                
-        if (this.isTrivialAccept()) {
-            /* If this is a task with no rules defined, there's no need to make API calls for predictions.
-             * Just return a stock response instead.
+        if (this.isTrivialClarabridgeRule()) {
+            /* 
+             * If this is a task with no rules defined and has a trivial Clarabridge rule 
+             * there's no need to make API calls for predictions. Just return a stock response instead.
              */
             docPredictions = (PredictionIterable<DocumentPrediction>) new PredictionIterableTrivial<DocumentPrediction>(
                 DocumentPrediction.class, this, items);
@@ -758,11 +759,11 @@ public class Task extends IdibonHash {
     
     /**
      * Private helper function to inspect the task and determine whether it qualifies
-     * as a trivial-accept case. Criteria include:
+     * as a trivial-Clarabridge rule case. Criteria to meet:
      *  1. No tuning dictionary entries
      *  2. A single feature 'ClarabridgeRule' consisting of empty arrays.
      */
-    private boolean isTrivialAccept() throws IOException {    
+    private boolean isTrivialClarabridgeRule() throws IOException {    
         JsonArray features = this.getJson().getJsonArray("features");
         
         // If there are dictionary tuning rules, this is not trivial

--- a/java-api-client/src/test/java/com/idibon/api/model/TaskTest.java
+++ b/java-api-client/src/test/java/com/idibon/api/model/TaskTest.java
@@ -127,7 +127,7 @@ public class TaskTest {
         Collection mockCollection = Collection.instance(null, "C");
         Task mockTask = Task.instance(mockCollection, taskJson);
 
-        java.lang.reflect.Method method = Task.class.getDeclaredMethod("isTrivialAccept");
+        java.lang.reflect.Method method = Task.class.getDeclaredMethod("isTrivialClarabridgeRule");
         method.setAccessible(true);
 
         assertThat(((boolean)method.invoke(mockTask)), is(false));
@@ -151,7 +151,7 @@ public class TaskTest {
         Collection mockCollection = Collection.instance(null, "C");
         Task mockTask = Task.instance(mockCollection, taskJson);
 
-        java.lang.reflect.Method method = Task.class.getDeclaredMethod("isTrivialAccept");
+        java.lang.reflect.Method method = Task.class.getDeclaredMethod("isTrivialClarabridgeRule");
         method.setAccessible(true);
 
         assertThat((boolean)method.invoke(mockTask), is(false));


### PR DESCRIPTION
The use of trivial predict was confusing. It is specifically
referring to the case of a special case of clarabridge rules.
So renamed a method and updates some comments to reflect this.

@idigary @texasmichelle @vybs 
